### PR TITLE
Better support for JSON Update commands + small fix for add!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.9-SNAPSHOT] - 2019-08-01
+
+### Changed
+- `corona.core-admin/update!` can handle list of JSON commands correctly and accepts optional settings as 3d argument, exactly like `corona.core-admin/add!` and `corona.core-admin/delete!`
+- `corona.core-admin/add!` sends single doc to the `/update/json/docs` Solr endpoint as specified in the Solr documentation.
+
 ## [0.1.8-SNAPSHOT] - 2019-04-30
 ### Fixed
 - `corona.query/terms-per-field->q` had to wrap term with quotes in case term has more than one word.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject corona "0.1.8-SNAPSHOT"
+(defproject corona "0.1.9-SNAPSHOT"
   :description "A clojure wrapper Solr client"
   :url "http://example.com/FIXME"
   :dependencies [[org.clojure/clojure "1.9.0"]

--- a/src/corona/index.clj
+++ b/src/corona/index.clj
@@ -25,15 +25,15 @@
 
   Usage:
 
-  (update-commands! client-config {:delete {:id \"id1\"}})
+  (update! client-config {:delete {:id \"id1\"}})
 
-  (update-commands! client-config {:add {:commitWithin 5000,
+  (update! client-config {:add {:commitWithin 5000,
                                 :overwrite false
                                 :doc {:f1 \"v1\"
                                       :f2 \"v2\"}}})
 
 
-  (update-commands! client-config [{:add {:commitWithin 5000
+  (update! client-config [{:add {:commitWithin 5000
                                           :overwrite false
                                           :doc {:f1 \"v1 \"
                                                 :f2 \"v2 \"}}}

--- a/src/corona/index.clj
+++ b/src/corona/index.clj
@@ -16,27 +16,43 @@
 ;; following API.
 ;; Source: https://lucene.apache.org/solr/guide/7_6/uploading-data-with-index-handlers.html#json-formatted-index-updates
 
+
 (defn update!
-  "Sends JSON Update Commands.
+  "Sends JSON Update Command(s).
   In general, the JSON update syntax supports all of the update commands that
   the XML update handler supports, through a straightforward mapping. Multiple
   commands, adding and deleting documents, may be contained in one message.
 
   Usage:
 
-  (update! client-config {:delete {:id \"id1\"}})
+  (update-commands! client-config {:delete {:id \"id1\"}})
 
-  (update! client-config {:add {:commitWithin 5000,
+  (update-commands! client-config {:add {:commitWithin 5000,
                                 :overwrite false
                                 :doc {:f1 \"v1\"
                                       :f2 \"v2\"}}})
 
-  Source: https://lucene.apache.org/solr/guide/6_6/uploading-data-with-index-handlers.html#UploadingDatawithIndexHandlers-SendingJSONUpdateCommands
+
+  (update-commands! client-config [{:add {:commitWithin 5000
+                                          :overwrite false
+                                          :doc {:f1 \"v1 \"
+                                                :f2 \"v2 \"}}}
+                                   {:delete {:id \"id1 \"}}])
+
+
+  Source: https://lucene.apache.org/solr/guide/8_1/uploading-data-with-index-handlers.html#UploadingDatawithIndexHandlers-SendingJSONUpdateCommands
   "
-  [client-config settings]
+  [client-config commands & [settings]]
   (let [url (utils/create-client-url client-config "/update")
+        trim (fn [str] (.substring (java.lang.String. str) 1 (- (count str) 1)))
+        request-body (if (not (map? commands))
+                       (let [parts (map #(trim (json/write-str %)) commands)
+                             joined-parts (clojure.string/join "," parts)]
+                         (str \{ joined-parts \}))
+                       (json/write-str commands))
         options {:throw-exceptions false
-                 :body             (json/write-str settings)
+                 :query-params     settings
+                 :body             request-body
                  :headers          {"Content-Type" "application/json"}
                  :as               :auto}
         {:keys [body]} @(http/post url options)]
@@ -84,10 +100,12 @@
   previous versions of the same document (see below).
   "
   [client-config doc-or-docs & [settings]]
-  (let [docs (if (sequential? doc-or-docs) doc-or-docs [doc-or-docs])
-        url (utils/create-client-url client-config "/update")
+  (let [url-suffix (if (map? doc-or-docs)
+                     "/update/json/docs"
+                     "/update")
+        url (utils/create-client-url client-config url-suffix)
         options {:query-params settings
-                 :body         (json/write-str docs)
+                 :body         (json/write-str doc-or-docs)
                  :headers      {"Content-Type" "application/json"}
                  :as           :auto}
         {:keys [body]} @(http/post url options)]


### PR DESCRIPTION
I've implemented ability to send several commands to `/update` Solr endpoint with `update!` func. According to the Solr docs the payload is not correct JSON and we can not make it work with normal hashmap, so some string manipulation was required. For `add!` func I implemented sending list to `/update` and single doc to `/update/json/docs` as specified in the [Solr docs](https://lucene.apache.org/solr/guide/8_1/uploading-data-with-index-handlers.html#UploadingDatawithIndexHandlers-SendingJSONUpdateCommands).

