### PR TITLE
Throw more informative error on JSON parse failure

### DIFF
--- a/src/corona/utils.clj
+++ b/src/corona/utils.clj
@@ -34,7 +34,7 @@ throw exception on any error."
   ([s key-fn]
      (try
        (json/read-str s :key-fn key-fn)
-       (catch Exception e
+       (catch Exception _
          (when *json-read-throw-on-error*
-           (throw e)))))
+           (throw (ex-info "JSON read error" {:string s}))))))
   ([str] (json-read-str str keyword)))


### PR DESCRIPTION
this ends up happening to me a decent amount where SOLR returns an error response that is XML.  Corona chokes on the json parsing but only gives me a message that says `< is an unexpected character`, so I can't see what SOLR is trying to tell me. It would be nice to see the string that it tried to parse on a JSON read error.