### PR TITLE
Post query

### DIFF
--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -173,48 +173,18 @@
 
 (defn query-handler
   [client-config handler settings]
-  (prn "client-config=" client-config)
-  (prn "settings=" settings)
-  (prn "handler=" handler)
   (let [handler-uri (str "/" (name handler))
         query-params (format-params settings)
         options {:query-params query-params
                  :as :auto}
         url (utils/create-client-url client-config handler-uri)]
-    (prn "query handler url=" url " options=" options)
-    (if (= (:method setting) :post)
-      (-> @(http/post url options) :body utils/json-read-str)
-      (-> @(http/get url options) :body utils/json-read-str)
-      )))
 
-(comment
-  (def client-config {:type :http, :host "127.0.0.1", :port 8983, :core :catalog-items})
-  (def handler :select)
-  (def settings {:q "id:1162409" :rows 15 :start 0 :fl [:id :name :outfit_ids] :wt :json})
-  (-> @(http/post "http://127.0.0.1:8983/solr/catalog-outfits/select" {:params setting})
-      :body utils/json-read-str)
+    (if (= (:method settings) :post)
+      (let [options-with-headers (assoc options
+                                        :headers {"Content-Type" "application/json; charset=utf-8"})]
+        (-> @(http/post url options-with-headers) :body utils/json-read-str))
+      (-> @(http/get url options) :body utils/json-read-str))))
 
-  (-> @(http/get "http://127.0.0.1:8983/solr/catalog-items/select" {:query-params (format-params settings)
-                                                                    :as :auto})
-      :body utils/json-read-str)
-
-  (-> @(http/post "http://127.0.0.1:8983/solr/catalog-items/select" {:query-params (format-params settings)
-                                                                     :headers {"Content-Type" "application/json; charset=utf-8"}
-                                                                     :as :auto})
-      :body utils/json-read-str)
-  
-
-  (http/post "http://127.0.0.1:8983/solr/catalog-items/select"
-             {:query-params (format-params settings)
-              :headers {"Content-Type" "application/json; charset=utf-8"}}
-             (fn [{:keys [status headers body error]}]
-               (if error
-                 (prn "failed " error)
-                 (prn "body " body))
-               ))
-  
-  (query-handler client-config handler settings)
-  )
 
 (defn query-term-vectors
   "Settings

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -173,50 +173,15 @@
 
 (defn query-handler
   [client-config handler settings]
-  ;;(prn "client-config" client-config)
-  ;;(prn  "handler=" handler)
-  ;;(prn "settings=" settings)
   (let [handler-uri (str "/" (name handler))
-        ;;query-params (format-params settings)
-        ;; options {:query-params query-params
-        ;;          :as :auto}
         url (utils/create-client-url client-config handler-uri)]
-    ;;(prn url)
     (if (= (:method settings) :get)
       (let [options {:query-params (format-params settings)
                      :as :auto}]
         (-> @(http/get url options) :body utils/json-read-str))
-      (let [options {;;:query-params (format-params settings)
-                     :params (format-params settings)
-                     :as :auto
-                     :headers {"Content-Type" "application/json; charset=utf-8"}}
-            response @(http/post url options)
-            _ (prn "foo1=" response)
-            response (-> response :body utils/json-read-str)
-            _ (prn "foo2=" response)]
-        
-        response
-        #_(->  :body utils/json-read-str)
-        #_(-> @(http/post url options) )
-        ))))
-
-(comment
-  (def client-config {:type :http, :host "127.0.0.1", :port 8983, :core :catalog-outfits})
-  (def handler :select)
-  (def settings {:q "id:275051"})
-  (query-handler client-config handler settings)
-  
-  
-  (-> @(http/post "http://127.0.0.1:8983/solr/catalog-outfits/select" {:body "{\"params\":{\"q\":\"id:275051\",\"rows\":10}}"
-                                                                       :headers {"Content-Type" "application/json; charset=utf-8"}
-                                                                       })
-      :body utils/json-read-str)
-
-  (query-handler client-config handler {:q "+id:1036202"
-                                        :method :post
-                                        :rows 15 :start 0 :fl [:id :updated_at :deleted_at :collage]})
-
-  client-config)
+      (let [options {:headers {"Content-Type" "application/json; charset=utf-8"}
+                     :body (json/write-str {:params settings})}]
+        (-> @(http/post url options) :body utils/json-read-str)))))
 
 (defn query-term-vectors
   "Settings


### PR DESCRIPTION
http GET has a limitation on how large the query string is. http POST has no such limitation.  Use http POST by default. If GET wants to be used attached a {:method :get} to the settings