### PR TITLE
Replace clojure.data.json with jsonista

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "http://example.com/FIXME"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.csv "0.1.4"]
-                 [org.clojure/data.json "0.2.6"]
                  [commons-io/commons-io "2.6"]
                  [funcool/cuerdas "2.0.5"]
                  [http-kit "2.4.0"]
                  [me.raynes/fs "1.4.6"]
+                 [metosin/jsonista "0.3.3"]
                  [ring/ring-codec "1.1.1"]]
   :source-paths ["src"]
   :profiles {:uberjar {:aot :all}}

--- a/src/corona/data_import.clj
+++ b/src/corona/data_import.clj
@@ -1,6 +1,6 @@
 (ns corona.data-import
   (:require
-   [clojure.data.json :as json]
+   [jsonista.core :as json]
    [corona.utils :as utils]
    [cuerdas.core :as cstr]
    [org.httpkit.client :as http]
@@ -63,4 +63,4 @@
         options {:query-params {:command "status"}
                  :as :auto}
         resp @(http/get url options)]
-    (update resp :body json/read-str :key-fn #(-> % cstr/kebab keyword))))
+    (update resp :body json/read-value (json/object-mapper {:encode-key-fn #(-> % cstr/kebab keyword)}))))

--- a/src/corona/index.clj
+++ b/src/corona/index.clj
@@ -1,6 +1,6 @@
 (ns corona.index
   (:require
-   [clojure.data.json :as json]
+   [jsonista.core :as json]
    [corona.utils :as utils]
    [org.httpkit.client :as http]))
 
@@ -46,10 +46,10 @@
   (let [url (utils/create-client-url client-config "/update")
         trim (fn [str] (.substring (java.lang.String. str) 1 (- (count str) 1)))
         request-body (if (not (map? commands))
-                       (let [parts (map #(trim (json/write-str %)) commands)
+                       (let [parts (map #(trim (json/write-value-as-string %)) commands)
                              joined-parts (clojure.string/join "," parts)]
                          (str \{ joined-parts \}))
-                       (json/write-str commands))
+                       (json/write-value-as-string commands))
         options {:throw-exceptions false
                  :query-params     settings
                  :body             request-body
@@ -104,7 +104,7 @@
                      "/update")
         url (utils/create-client-url client-config url-suffix)
         options {:query-params settings
-                 :body         (json/write-str doc-or-docs)
+                 :body         (json/write-value-as-string doc-or-docs)
                  :headers      {"Content-Type" "application/json"}
                  :as           :auto}]
     (-> @(http/post url options) :body utils/json-read-str)))
@@ -119,7 +119,7 @@
   (let [body {:delete id-ids-or-query-map}
         url (utils/create-client-url client-config "/update")
         options {:query-params settings
-                 :body         (json/write-str body)
+                 :body         (json/write-value-as-string body)
                  :headers      {"Content-Type" "application/json"}
                  :as           :auto}]
     (-> @(http/post url options) :body utils/json-read-str)))

--- a/src/corona/ltr.clj
+++ b/src/corona/ltr.clj
@@ -1,6 +1,6 @@
 (ns corona.ltr
   (:require
-   [clojure.data.json :as json]
+   [jsonista.core :as json]
    [clojure.string :as string]
    [corona.utils :as utils]
    [org.httpkit.client :as http])
@@ -85,7 +85,7 @@
   [client-config features]
   (delete-feature-store! client-config (-> features first :store))
   (let [url (make-feature-store-url client-config)
-        options {:body    (json/write-str features)
+        options {:body    (json/write-value-as-string features)
                  :headers {"Content-Type" "application/json"}
                  :as      :auto}]
     (-> @(http/put url options) :body utils/json-read-str)))
@@ -182,7 +182,7 @@
   NOTE: only supported with :http config type."
   [client-config model]
   (let [url (make-model-store-base-url client-config)
-        options {:body    (json/write-str model)
+        options {:body    (json/write-value-as-string model)
                  :headers {"Content-Type" "application/json"}
                  :as      :auto}]
     (-> @(http/put url options) :body utils/json-read-str)))

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -1,6 +1,6 @@
 (ns corona.query
   (:require
-   [clojure.data.json :as json]
+   [jsonista.core :as json]
    [clojure.string :as string]
    [corona.utils :as utils]
    [org.httpkit.client :as http]))
@@ -180,7 +180,7 @@
                      :as :auto}]
         (-> @(http/get url options) :body utils/json-read-str))
       (let [options {:headers {"Content-Type" "application/json; charset=utf-8"}
-                     :body (json/write-str {:params settings})}]
+                     :body (json/write-value-as-string {:params settings})}]
         (-> @(http/post url options) :body utils/json-read-str)))))
 
 (defn query-term-vectors

--- a/src/corona/schema.clj
+++ b/src/corona/schema.clj
@@ -1,7 +1,7 @@
 (ns corona.schema
   (:require
    [org.httpkit.client :as http]
-   [clojure.data.json :as json]
+   [jsonista.core :as json]
    [clojure.string :as string]
    [corona.utils :as utils]))
 
@@ -70,7 +70,7 @@
   "
   [client-config body]
   (let [url (make-schema-url client-config)
-        options {:body         (json/write-str body)
+        options {:body         (json/write-value-as-string body)
                  :headers      {"Content-Type" "application/json"}
                  :as           :auto}]
     (-> @(http/post url options) :body utils/json-read-str)))

--- a/src/corona/utils.clj
+++ b/src/corona/utils.clj
@@ -1,5 +1,5 @@
 (ns corona.utils
-  (:require [clojure.data.json :as json]))
+  (:require [jsonista.core :as json]))
 
 (def default-http-config
   "Needs a custom :core value"
@@ -31,10 +31,12 @@ returning nil when parsing JSON fails."}
   "Try to parse JSON string. Returns nil if string is empty or unable to parse.
 Default :key-fn is \"keyword\". If *json-read-throw-on-error* was set to true,
 throw exception on any error."
-  ([s key-fn]
-     (try
-       (json/read-str s :key-fn key-fn)
-       (catch Exception _
-         (when *json-read-throw-on-error*
-           (throw (ex-info "JSON read error" {:string s}))))))
-  ([str] (json-read-str str keyword)))
+  [s & [key-fn]]
+  (try
+    (let [obj-mapper (if key-fn
+                       (json/object-mapper {:decode-key-fn key-fn})
+                       json/keyword-keys-object-mapper)]
+      (json/read-value s obj-mapper))
+    (catch Exception _
+      (when *json-read-throw-on-error*
+        (throw (ex-info "JSON read error" {:string s}))))))


### PR DESCRIPTION
Replace `clojure.data.json` with [jsonista](https://github.com/metosin/jsonista)

It's claimed to be faster than `clojure.data.json` and [Cheshire](https://github.com/dakrone/cheshire).

I ran a criterium benchmark test encoding / decoding a vector of 66 items, each item has 77 keys. 

For edn->json, it's about 8 times faster.
```clj
(require '[criterium.core :refer [bench]])

(bench (clojure.json/write-str items))
Evaluation count : 17340 in 60 samples of 289 calls.
             Execution time mean : 3.669788 ms
    Execution time std-deviation : 188.142242 µs
   Execution time lower quantile : 3.467954 ms ( 2.5%)
   Execution time upper quantile : 4.181521 ms (97.5%)
                   Overhead used : 9.434892 ns

Found 8 outliers in 60 samples (13.3333 %)
	low-severe	 5 (8.3333 %)
	low-mild	 3 (5.0000 %)
 Variance from outliers : 36.8774 % Variance is moderately inflated by outliers

(bench (jsonista/write-value-as-string items))
Evaluation count : 145980 in 60 samples of 2433 calls.
             Execution time mean : 435.134099 µs
    Execution time std-deviation : 20.601857 µs
   Execution time lower quantile : 410.088818 µs ( 2.5%)
   Execution time upper quantile : 472.552166 µs (97.5%)
                   Overhead used : 9.434892 ns

Found 2 outliers in 60 samples (3.3333 %)
	low-severe	 1 (1.6667 %)
	low-mild	 1 (1.6667 %)
 Variance from outliers : 33.5769 % Variance is moderately inflated by outliers
```


For json->edn, it's about 3 times faster.
```clj
(bench (clojure.json/read-str s :key-fn keyword))
Evaluation count : 22260 in 60 samples of 371 calls.
             Execution time mean : 2.730394 ms
    Execution time std-deviation : 72.820398 µs
   Execution time lower quantile : 2.683357 ms ( 2.5%)
   Execution time upper quantile : 2.930342 ms (97.5%)
                   Overhead used : 2.575368 ns

Found 5 outliers in 60 samples (8.3333 %)
	low-severe	 3 (5.0000 %)
	low-mild	 2 (3.3333 %)
 Variance from outliers : 14.1762 % Variance is moderately inflated by outliers

(bench (jsonista/read-value s jsonista/keyword-keys-object-mapper))
Evaluation count : 69180 in 60 samples of 1153 calls.
             Execution time mean : 875.646353 µs
    Execution time std-deviation : 21.914093 µs
   Execution time lower quantile : 863.313895 µs ( 2.5%)
   Execution time upper quantile : 917.030129 µs (97.5%)
                   Overhead used : 2.575368 ns

Found 4 outliers in 60 samples (6.6667 %)
	low-severe	 2 (3.3333 %)
	low-mild	 2 (3.3333 %)
 Variance from outliers : 12.5941 % Variance is moderately inflated by outliers
```