### PR TITLE
Pass server errors to caller

### DIFF
--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -177,8 +177,13 @@
         query-params (format-params settings)
         options {:query-params query-params
                  :as :auto}
-        url (utils/create-client-url client-config handler-uri)]
-    (-> @(http/get url options) :body utils/json-read-str)))
+        url (utils/create-client-url client-config handler-uri)
+        response @(http/get url options)
+        status (:status response)]
+    (if-not (#{400 200} status)
+      {:error {:msg "Solr server returned non-200 status code. The server logs may contain more details."
+               :status status}}
+      (-> response :body utils/json-read-str))))
 
 (defn query-term-vectors
   "Settings


### PR DESCRIPTION
As I understand it there are a couple kinds of solr errors:
- Errors caused by problematic solr queries
- Errors caused by problematic HTTP requests
- Server errors not necessarily caused by the client

Errors falling in the first bucket are sent back in the body of the
http response with a 400 status code, but the second two categories
are returned with an empty body and non-200 status code.

I couldn't find any documentation how solr returns errors, but did
find this list of HTTP status codes that solr employs:

https://github.com/apache/solr/blob/67c55b53a49d56b343497f06231375540fee7395/solr/solrj/src/java/org/apache/solr/common/SolrException.java#L39

If you want to see an example of a query that was silently failing,
just create a really long query and notice that you get a nil response
instead of a reponse with {:docs nil :numFound 0}. Then check the
server logs for a message like "o.e.j.h.HttpParser URI is too large >819".

I do consider this a breaking change, but I feel that the current
behavior is just wrong and needs to be corrected.