### PR TITLE
Special char handling

### DIFF
--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -117,7 +117,6 @@
                                    terms)
                      sorted-terms (sort-by second > (remove nil? scored-terms))
                      top-terms (take top sorted-terms)
-                     top-terms-count (count top-terms)
                      top-terms-total-score (reduce (fn [acc term]
                                                      (+ acc (second term)))
                                                    0

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -145,7 +145,7 @@
         (string/join " ")))
 
 (defn interesting-terms-per-field->q
-  [interesting-terms-per-field settings]
+  [interesting-terms-per-field]
   (->> interesting-terms-per-field
        vals
        (map terms-per-field->q)
@@ -394,7 +394,7 @@
         int-terms (term-vectors-resp->interesting-terms-per-field
                    tv-resp
                    settings)
-        mltq (interesting-terms-per-field->q int-terms settings)
+        mltq (interesting-terms-per-field->q int-terms)
         fq (string/join " " [(:fq settings) (format "-(%s)" tv-q)])
         settings (-> settings
                      (assoc :mltq mltq)


### PR DESCRIPTION
The alternative is to prevent bad chars from being indexed, but
some users might want to search for these special chars, and they
can't add their own escaping without copy-pasting
corona.query/query-mlt-tv-edismax since they data that needs cleaning
is fetched inside this function.