### PR TITLE
Add ability to supply multiple _route_s to query-mlt-tv-edismax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.16] - 2022-12-08
+- Add ability to supply multiple routes to `corona.query/query-mlt-tv-edismax`
+
 ## [0.1.15] - 2022-07-27
 - Escape characters for query-mlt-tv-edismax's mltq params
 

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -384,7 +384,7 @@
   The name of the id field
 
   :mlt.ids
-  A lest of ids and boosts e.g. [[\"12345\" 3] [\"12346\" 2]]
+  A list of ids and boosts e.g. [[\"12345\" 3] [\"12346\" 2]]
 
   :mlt.top <int> 
   The number of top interesting terms to use, per field.

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -392,6 +392,12 @@
   :q
   \"Regular edismax query\" that is added to mlt query
 
+  :_route_, default: searches all shards
+  The value will be hashed to find which shards to search for similar items.
+
+  :original-documents_route_, default: searches all shards
+  The value will be hashed to find which which shards the mlt.ids belong to.
+
   Special vars:
 
   ${mltq}
@@ -416,6 +422,7 @@
                  {:q tv-q
                   :tv.fl (:mlt.fl settings)
                   :tv.all true
+                  :_route_ (:original-documents_route_ settings)
                   :rows (count (:mlt.ids settings))})
         int-terms (term-vectors-resp->interesting-terms-per-field
                    tv-resp


### PR DESCRIPTION
This can be useful when working with many shards and when you only care about term Document Frequency within particular shards.