### PR TITLE
Allow passing in multiple filter queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `corona.query/query` and `corona.query/query-mlt` no longer combine multiple `:fq` values into a single one.
+
 ## [0.1.16] - 2022-12-08
 - Add ability to supply multiple routes to `corona.query/query-mlt-tv-edismax`
 

--- a/src/corona/query.clj
+++ b/src/corona/query.clj
@@ -23,11 +23,16 @@
   (reduce-kv
    (fn [m k v]
      (let [k* (format-param k)]
-       (assoc m k* (string/join (if (#{"sort" "fl" "tv.fl" "mlt.fl"} k*)
-                                  ","
-                                  " ")
-                                (format-values v)))))
-   {}
+       (if (= "fq" k*)
+         (reduce (fn [acc v]
+                   (conj acc [k* v]))
+                 m
+                 (format-values v))
+         (conj m [k* (string/join (if (#{"sort" "fl" "tv.fl" "mlt.fl"} k*)
+                                    ","
+                                    " ")
+                                  (format-values v))]))))
+   []
    m))
 
 


### PR DESCRIPTION
This is needed because sometimes a caller needs to be able to pass multiple fq values. For example, I haven't found a way to use frange with an unrelated boolean query. The following throws a parse error:

    +myfield:"valA" {!frange l=2}termfreq(myfield,"valB")

But if expressed as two separate filters, it behaves as expected:

    +myfield:"valA"
    {!frange l=2}termfreq(myfield,"valB")

This could be considered a breaking change. Queries will continue working as before, but the caching behavior will be different for calls that passed in a vector as a value for :fq. See the examples in the docs[0] for how the caching will change.

Callers who are currently passing a vector can restore the previous behavior by calling `(clojure.string/join " " <the vector>)`.

[0] https://solr.apache.org/guide/8_11/common-query-parameters.html#fq-filter-query-parameter